### PR TITLE
Remove to-markup

### DIFF
--- a/functions/candidate/event.json
+++ b/functions/candidate/event.json
@@ -1,5 +1,5 @@
 {
   "user": "ksespinola",
   "repo": "serverless-gitflow",
-  "release": "0.0.6"
+  "release": "0.0.8"
 }

--- a/functions/candidate/s-function.json
+++ b/functions/candidate/s-function.json
@@ -11,7 +11,8 @@
   "custom": {
     "runtime": {
       "babel": {
-        "presets": ["es2015",  "stage-0", "react"]
+        "presets": ["es2015",  "stage-0", "react"],
+        "extensions": [".js", ".jsx"]
       }
     }
   },

--- a/functions/candidate/s-function.json
+++ b/functions/candidate/s-function.json
@@ -18,7 +18,7 @@
   "endpoints": [
     {
       "path": "candidate",
-      "method": "GET",
+      "method": "POST",
       "type": "AWS",
       "authorizationType": "none",
       "authorizerFunction": false,

--- a/functions/release/s-function.json
+++ b/functions/release/s-function.json
@@ -18,7 +18,7 @@
   "endpoints": [
     {
       "path": "release",
-      "method": "GET",
+      "method": "POST",
       "type": "AWS",
       "authorizationType": "none",
       "authorizerFunction": false,

--- a/lib/services/candidate.js
+++ b/lib/services/candidate.js
@@ -29,10 +29,10 @@ const createBody = compose(
 
 github.authenticate(auth.toJS());
 
-export default (user, repo, release) => new Promise((resolve, reject) => {
+export default (user, repo, release) => {
   const candidate = `${CANDIDATE_NAME}/${release}`;
 
-  getBranch({
+  return getBranch({
     user,
     repo,
     branch: MASTER_BRANCH,
@@ -79,11 +79,5 @@ export default (user, repo, release) => new Promise((resolve, reject) => {
         body: createBody({ pulls }),
       })
     )
-  )
-  .then((response) => {
-    resolve(response);
-  })
-  .catch((err) => {
-    reject(err);
-  });
-});
+  );
+};

--- a/lib/services/candidate.js
+++ b/lib/services/candidate.js
@@ -1,12 +1,11 @@
 import Promise from 'bluebird';
 import moment from 'moment';
 import React from 'react';
-import toMarkdown from 'to-markdown';
 import { compose } from 'ramda';
 import { renderToStaticMarkup } from 'react-dom/server';
 import auth from './../config/auth';
 import github from './../config/github';
-import Candidate from './../components/Candidate';
+import Candidate from './../components/Candidate.jsx';
 
 const { DEVELOP_BRANCH, MASTER_BRANCH, CANDIDATE_NAME } = process.env;
 
@@ -22,10 +21,7 @@ const pullsAfterDate = (date, pulls) =>
 
 const getTitle = release => `Candidate ${release}`;
 
-const createBody = compose(
-  html => toMarkdown(html, { gfm: true }),
-  props => renderToStaticMarkup(<Candidate {...props} />)
-);
+const createBody = props => renderToStaticMarkup(<Candidate {...props} />);
 
 github.authenticate(auth.toJS());
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "moment": "^2.13.0",
     "react": "^15.1.0",
     "react-dom": "^15.0.2",
-    "serverless-runtime-babel": "0.0.6"
+    "serverless-runtime-babel": "0.0.6",
+    "to-markdown": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^2.10.2",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "moment": "^2.13.0",
     "react": "^15.1.0",
     "react-dom": "^15.0.2",
-    "serverless-runtime-babel": "0.0.6",
-    "to-markdown": "^3.0.0"
+    "serverless-runtime-babel": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^2.10.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,59 @@
+const webpack = require('webpack');
+
+module.exports = {
+
+  target: 'node',
+
+  externals: [
+    'aws-sdk'
+  ],
+
+  devtool: 'source-map',
+
+  resolve: {
+    modulesDirectories: [
+      'node_modules',
+    ],
+    extensions: ['', '.js', '.jsx', '.json'],
+  },
+
+  plugins: [
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        unused: true,
+        dead_code: true,
+        warnings: false,
+        drop_debugger: true
+      }
+    })
+  ],
+
+  module: {
+    loaders: [
+      {
+        test: /\.json$/,
+        loader: 'json',
+      },
+      {
+        test: /\.(png|jpg)$/,
+        loader: 'file?name=[name].[ext]',
+      },
+      {
+        test: /\.(woff|svg|eot|ttf|woff2)$/,
+        loader: 'file?name=[sha512:hash:base64:7].[ext]',
+      },
+      {
+        test: [/\.js$/, /\.jsx$/],
+        loader: 'babel',
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015', 'stage-0', 'react']
+        }
+      }
+    ]
+  }
+
+};


### PR DESCRIPTION
to-markup uses jsdom which requires native modules to run. This is not supported in lamda currently.
